### PR TITLE
feat: create stub files for type hinting

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install pytest cookiecutter nox pre-commit pytest-cookies pyyaml
+        run: python -m pip install nox
       - name: test the repository
-        run: pytest --color=yes tests
+        run: nox
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,14 @@ import nox
 @nox.session(reuse_venv=True)
 def test(session):
     """Run all the test using the environment varialbe of the running machine."""
-    session.install("pytest", "cookiecutter", "nox", "pre-commit", "pytest-cookies>=0.7.0", "pyyaml")
+    session.install(
+        "pytest",
+        "cookiecutter",
+        "nox",
+        "pre-commit",
+        "pytest-cookies>=0.7.0",
+        "pyyaml",
+        "pytest-regressions",
+    )
     test_files = session.posargs or ["tests"]
     session.run("pytest", "--color=yes", *test_files)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -51,6 +51,18 @@ def test_build_yaml(cookies: Cookies) -> None:
     data = yaml.safe_load((workflows_path/"unit.yaml").read_text())
     data = yaml.safe_load((workflows_path/"release.yaml").read_text())
 
+def test_stub_file(cookies: Cookies, file_regression) -> None:
+    """Build the documentation and check github actions files
+
+    Args:
+        cookies: the cookies to build
+        file_regression: the file regression fixture
+    """
+    result = cookies.bake()
+    subprocess.check_call(["nox", "-s" "stubgen"], cwd=result.project_path)
+    stub_path = Path(result.project_path)/"stubs"/"package_skeleton"/"__init__.pyi"
+    file_regression.check(stub_path.read_text(), extension=".pyi")
+
 
 
 

--- a/tests/test_build/test_stub_file.pyi
+++ b/tests/test_build/test_stub_file.pyi
@@ -1,0 +1,7 @@
+__version__: str
+__author__: str
+__email__: str
+
+class Hello:
+    msg: str
+    def hello_world(self) -> str: ...

--- a/{{cookiecutter.github_repo_name}}/noxfile.py
+++ b/{{cookiecutter.github_repo_name}}/noxfile.py
@@ -5,6 +5,7 @@ The nox run are build in isolated environment that will be stored in .nox. to fo
 
 import nox
 
+nox.options.sessions = ["lint", "test", "docs", "mypy"]
 
 @nox.session(reuse_venv=True)
 def lint(session):

--- a/{{cookiecutter.github_repo_name}}/noxfile.py
+++ b/{{cookiecutter.github_repo_name}}/noxfile.py
@@ -47,9 +47,8 @@ def mypy(session):
     session.run("mypy", *test_files)
 
 @nox.session(reuse_venv=True)
-def stub(session):
+def stubgen(session):
     """Generate stub files for the lib but requires human attention before merge."""
     session.install("mypy")
-    package = session.posargs[0] or "{{ cookiecutter.project_slug }}"
-    options = ["--include-private", "--no-import", "--no-setup-py"]
-    session.run("stubgen", "-p", package, "-o", "stubs", *options)
+    package = session.posargs or ["{{ cookiecutter.project_slug }}"]
+    session.run("stubgen", "-p", package[0], "-o", "stubs", "--include-private")

--- a/{{cookiecutter.github_repo_name}}/noxfile.py
+++ b/{{cookiecutter.github_repo_name}}/noxfile.py
@@ -45,3 +45,11 @@ def mypy(session):
     session.install("mypy")
     test_files = session.posargs or ["{{ cookiecutter.project_slug }}"]
     session.run("mypy", *test_files)
+
+@nox.session(reuse_venv=True)
+def stub(session):
+    """Generate stub files for the lib but requires human attention before merge."""
+    session.install("mypy")
+    package = session.posargs[0] or "{{ cookiecutter.project_slug }}"
+    options = ["--include-private", "--no-import", "--no-setup-py"]
+    session.run("stubgen", "-p", package, "-o", "stubs", *options)

--- a/{{cookiecutter.github_repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.github_repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -5,4 +5,4 @@ import {{ cookiecutter.project_slug }}
 
 def test_hello_world():
     """Hello world test."""
-    assert {{ cookiecutter.project_slug }}Hello().hello_world() == "hello world !"
+    assert {{ cookiecutter.project_slug }}.Hello().hello_world() == "hello world !"

--- a/{{cookiecutter.github_repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
+++ b/{{cookiecutter.github_repo_name}}/tests/test_{{cookiecutter.project_slug}}.py
@@ -5,4 +5,4 @@ import {{ cookiecutter.project_slug }}
 
 def test_hello_world():
     """Hello world test."""
-    assert {{ cookiecutter.project_slug }}.hello_world() == "hello world !"
+    assert {{ cookiecutter.project_slug }}Hello().hello_world() == "hello world !"

--- a/{{cookiecutter.github_repo_name}}/{{cookiecutter.project_slug}}/__init__.py
+++ b/{{cookiecutter.github_repo_name}}/{{cookiecutter.project_slug}}/__init__.py
@@ -5,10 +5,16 @@ __author__ = "{{ cookiecutter.author }}"
 __email__ = "{{ cookiecutter.author_email }}"
 
 
-def hello_world() -> str:
-    """Hello world demo method.
+class Hello:
+    """Hello world class."""
 
-    Returns:
-        the hello world string
-    """
-    return "hello world !"
+    msg = "hello world !"
+    "the message to print"
+
+    def hello_world(self) -> str:
+        """Hello world demo method.
+
+        Returns:
+            the hello world string
+        """
+        return self.msg

--- a/{{cookiecutter.github_repo_name}}/{{cookiecutter.project_slug}}/py.typed
+++ b/{{cookiecutter.github_repo_name}}/{{cookiecutter.project_slug}}/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The mypy package uses inline types.


### PR DESCRIPTION
Fix #75 

- create a nox session to build the stub files 
- add a py.typed file to be compatible with PEP 561
- test the stub generation 
- create a class in __init__.py to test the build lib