### PR TITLE
fix: add a version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,10 @@
-Python lib
-==========
+Pypackage
+=========
+
+.. image:: https://img.shields.io/github/v/release/12rambau/pypackage?logo=github&logoColor=white
+   :alt: GitHub release (with filter)
+   :target: https://github.com/12rambau/pypackage/releases
+
 
 The skeleton of a python lib embeding what I like:
 


### PR DESCRIPTION
This is done to trigger the automatic issue in pypackage-skeleton, it will be the final touch before the real release of v0.2