### PR TITLE
use the latest version of licensecheck

### DIFF
--- a/package/.pre-commit-config.yaml.jinja
+++ b/package/.pre-commit-config.yaml.jinja
@@ -39,7 +39,7 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/FHPythonUtils/LicenseCheck
-    rev: "2023.1.1"
+    rev: "2023.5.1"
     hooks:
       - id: licensecheck
         stages: [commit]


### PR DESCRIPTION
It seems it's leading to an error with the latest versions of setuptools: 

```
 Traceback (most recent call last):
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/bin/licensecheck", line 5, in <module>
    from licensecheck import cli
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/lib/python3.12/site-packages/licensecheck/__init__.py", line 13, in <module>
    from licensecheck import formatter, get_deps
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/lib/python3.12/site-packages/licensecheck/get_deps.py", line 9, in <module>
    import requirements
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/lib/python3.12/site-packages/requirements/__init__.py", line 19, in <module>
    from .parser import parse
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/lib/python3.12/site-packages/requirements/parser.py", line 23, in <module>
    from .requirement import Requirement
  File "/home/vscode/.cache/pre-commit/repotehnz5go/py_env-python3.12/lib/python3.12/site-packages/requirements/requirement.py", line 24, in <module>
    from pkg_resources import Requirement as Req
ModuleNotFoundError: No module named 'pkg_resources'
```