### PR TITLE
fix: only test the distributed packages

### DIFF
--- a/package/pyproject.toml.jinja
+++ b/package/pyproject.toml.jinja
@@ -107,4 +107,4 @@ non_interactive = true
 warn_redundant_casts = true
 
 [tool.licensecheck]
-using = "PEP631:test;doc"
+using = "PEP631"


### PR DESCRIPTION
There is no reason to actually test the dev related packages