### PR TITLE
fix: ignore test notebooks

### DIFF
--- a/package/.gitignore.jinja
+++ b/package/.gitignore.jinja
@@ -135,3 +135,6 @@ dmypy.json
 
 # image tmp file
 *Zone.Identifier
+
+# debugging notebooks
+test.ipynb


### PR DESCRIPTION
Fix #153 

The tests notebook should be removed from distant repositories I always call them test and they are always ipynb files.