### PR TITLE
fix: use uv as a backend for nox session

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -31,6 +31,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install nox
+        run: python -m pip install nox[uv]
       - name: test the repository
         run: nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ The nox run are build in isolated environment that will be stored in .nox. to fo
 import nox
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, venv_backend="uv")
 def test(session):
     """Run all the test using the environment variable of the running machine."""
     session.install(

--- a/package/.github/workflows/release.yaml.jinja
+++ b/package/.github/workflows/release.yaml.jinja
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
-        run: pip install twine build nox
+        run: pip install twine build nox[uv]
       - name: update citation date
         run: nox -s release-date
       - name: Build and publish

--- a/package/.github/workflows/unit.yaml.jinja
+++ b/package/.github/workflows/unit.yaml.jinja
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - uses: pre-commit/action@v3.0.0
 
   mypy:
@@ -27,9 +27,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install nox
-        run: pip install nox
+        run: pip install nox[uv]
       - name: run mypy checks
         run: nox -s mypy
 
@@ -40,9 +40,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install nox
-        run: pip install nox
+        run: pip install nox[uv]
       - name: build static docs
         run: nox -s docs
 
@@ -66,7 +66,7 @@ jobs:
         with:
           python-version: {% raw -%}${{ matrix.python-version }}{% endraw %}
       - name: Install nox
-        run: pip install nox
+        run: pip install nox[uv]
       - name: test with pytest
         run: nox -s ci-test
       - name: assess dead fixtures

--- a/package/noxfile.py.jinja
+++ b/package/noxfile.py.jinja
@@ -9,21 +9,21 @@ import nox
 
 nox.options.sessions = ["lint", "test", "docs", "mypy"]
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, venv_backend="uv")
 def lint(session):
     """Apply the pre-commits."""
     session.install("pre-commit")
     session.run("pre-commit", "run", "--all-files", *session.posargs)
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, venv_backend="uv")
 def test(session):
     """Run the selected tests and report coverage in html."""
     session.install(".[test]")
     test_files = session.posargs or ["tests"]
     session.run("pytest", "--cov", "--cov-report=html", *test_files)
 
-@nox.session(reuse_venv=True, name="ci-test")
+@nox.session(reuse_venv=True, name="ci-test", venv_backend="uv")
 def ci_test(session):
     """Run all the test and report coverage in xml."""
     session.install(".[test]")
@@ -31,14 +31,14 @@ def ci_test(session):
     session.run("pytest", "--cov", "--cov-report=xml")
 
 
-@nox.session(reuse_venv=True, name="dead-fixtures")
+@nox.session(reuse_venv=True, name="dead-fixtures", venv_backend="uv")
 def dead_fixtures(session):
     """Check for dead fixtures within the tests."""
     session.install(".[test]")
     session.run("pytest", "--dead-fixtures")
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, venv_backend="uv")
 def docs(session):
     """Build the documentation."""
     build = session.posargs.pop() if session.posargs else "html"
@@ -48,7 +48,7 @@ def docs(session):
     session.run("python", "tests/check_warnings.py")
 
 
-@nox.session(name="mypy", reuse_venv=True)
+@nox.session(name="mypy", reuse_venv=True, venv_backend="uv")
 def mypy(session):
     """Run a mypy check of the lib."""
     session.install("mypy")
@@ -56,7 +56,7 @@ def mypy(session):
     session.run("mypy", *test_files)
 
 
-@nox.session(reuse_venv=True)
+@nox.session(reuse_venv=True, venv_backend="uv")
 def stubgen(session):
     """Generate stub files for the lib but requires human attention before merge."""
     session.install("mypy")
@@ -64,7 +64,7 @@ def stubgen(session):
     session.run("stubgen", "-p", package[0], "-o", "stubs", "--include-private")
 
 
-@nox.session(name="release-date", reuse_venv=True)
+@nox.session(name="release-date", reuse_venv=True, venv_backend="uv")
 def release_date(session):
     """Update the release date of the citation file."""
     current_date = datetime.datetime.now().strftime("%Y-%m-%d")

--- a/package/pyproject.toml.jinja
+++ b/package/pyproject.toml.jinja
@@ -59,7 +59,7 @@ only-include = ["{{ project_slug }}"]
 dependencies = [
   "pre-commit",
   "commitizen",
-  "nox"
+  "nox[uv]"
 ]
 post-install-commands = ["pre-commit install"]
 


### PR DESCRIPTION
Fix #189 
It is making all the nox sessions way faster as the installation step is performed 10x faster. Specifically useful for projects with huge dependecy graph. 