### PR TITLE
fix: checkout files for coverage

### DIFF
--- a/package/.github/workflows/unit.yaml.jinja
+++ b/package/.github/workflows/unit.yaml.jinja
@@ -83,6 +83,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: coverage


### PR DESCRIPTION
as discovered recently in a dedicated issue of the codecov-action repository (https://github.com/codecov/codecov-action/issues/1589) the action requires to have the files checkout as well to link them in the web interface. The xml file in itself is not send alone but along with the other files as well. 

This change will make sure the reports in the codecov.io are able to display the full length of the results. 